### PR TITLE
Added arbitrary avg and unsorted all peaks options. Version bump to v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # scilightcon Change Log
 
+## [0.4.1] 2026-01-26
+### Added
+ - Added options to provide an arbitrary average value and return all unsorted peaks in peak_detect()
+
 ## [0.3.2] 2024-07-25
 ### Changed
 - Removed log parsing time range granularity by day in scilightcon.datasets.LogsReader

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,6 +42,7 @@ steps:
     python -m pip install --upgrade pip
     pip install -r requirements.txt
     pip install -r doc_requirements.txt
+    pip install setuptools
     pip install wheel
     pip install twine
   displayName: 'Install dependencies'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,10 +14,13 @@ strategy:
       python.version: '3.11'
     linuxPython37:
       imageName: 'ubuntu-latest'
-      python.version: '3.7'
+      python.version: '3.13'
     windowsPython311:
       imageName: 'windows-latest'
       python.version: '3.11'
+    windowsPython313:
+      imageName: 'windows-latest'
+      python.version: '3.13'
 
 pool:
   vmImage: $(imageName)
@@ -26,7 +29,7 @@ steps:
 
 - task: AzureKeyVault@1
   inputs:
-    azureSubscription: 'LCURSServiceConnection'
+    azureSubscription: 'scisw-service-connection'
     KeyVaultName: 'scisw-general-keyvault'
     SecretsFilter: '*'
     RunAsPreJob: true

--- a/scilightcon/__init__.py
+++ b/scilightcon/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.2"
+__version__ = "0.4.1"
 
 from . import plot
 from . import utils

--- a/scilightcon/datasets/_base.py
+++ b/scilightcon/datasets/_base.py
@@ -26,15 +26,15 @@ def load_csv_data(
 ):
     """
     Loads `data_file_name` from `data_module` with `importlib.resources`.
-    
+
     Examples:
         >>> from scilightcon.datasets import load_csv_data
         >>> data, header = load_csv_data('Hg_lines.csv')
 
     Args:
-        data_file_name (str): Name of csv file to be loaded from `data_module/data_file_name`. 
+        data_file_name (str): Name of csv file to be loaded from `data_module/data_file_name`.
         data_module (str or module):  Module where data lives. The default is `'scilightcon.datasets.data'`
-   
+
     Returns:
         data (ndarray): A 2D array with each row representing one sample and each column representing the features of a given sample. Shape: n_samples, n_features
         target (ndarry): A 1D array holding target variables for all the samples in `data`. For example target[0] is the target variable for data[0]. Shape (n_samples,)
@@ -51,7 +51,7 @@ def _read_csv_file(csv_file_path):
         possibly_header = next(data_file)
         header = [''] * len(possibly_header)
         is_header = possibly_header[0][0] == '#'
-        if is_header:            
+        if is_header:
             header = possibly_header
             header[0] = header[0][1:]
             header = [entry.strip() for entry in header]
@@ -71,33 +71,33 @@ def _read_csv_file(csv_file_path):
         for i, ir in enumerate(data_file):
             if i>=n_header:
                 data[i-n_header] = np.asarray(ir, dtype=np.float64)
-        
+
         return data, header
 
 def load_zipped_csv_data(data_file_name, *, data_module=DATA_MODULE):
     """Extracts gzip file to csv.
-    
+
     Examples:
         >>> from scilightcon.datasets import load_zipped_csv_data # doctest: +SKIP
         >>> data_file_name = r'C:\Code\lightcon-scipack\scilightcon\datasets\data\data_test_detect_peaks.csv.gz' # doctest: +SKIP
         >>> data, header = _load_zipped_csv_data(data_file_name) # doctest: +SKIP
-        
+
     Args:
         data_file_name (str): Path of the file that needs to be extracted
         data_module (str or module):  Module where data lives. The default is `'scilightcon.datasets.data'`
 
     Returns:
-        data (Ndarray): A 2D array of data with headers excluded. Shape (n_samples, n_columns)    
+        data (Ndarray): A 2D array of data with headers excluded. Shape (n_samples, n_columns)
         header (List): Column names or empty strings. Shape (n_columns)
     """
     temp_dir = tempfile.gettempdir()
-    temp_path = os.path.join(temp_dir, 'extracted.csv') 
+    temp_path = os.path.join(temp_dir, 'extracted.csv')
 
     gz_file_path = _get_path(scilightcon.datasets.DATA_MODULE, data_file_name)
     with gzip.open(gz_file_path, 'r') as file_in:
             with open(temp_path, 'wb') as file_out:
                 shutil.copyfileobj(file_in, file_out)
-    
+
     return _read_csv_file(temp_path)
 
 def load_EO_filter_transmissions(
@@ -117,7 +117,7 @@ def load_EO_filter_transmissions(
         filter (str): `lp_400nm`, `lp_450nm`, `lp_500nm`, `lp_550nm`, `lp_600nm`, `lp_600nm`, `lp_700nm`, `lp_750nm`, `sp_400nm`, `sp_500nm`, `sp_600nm` or `sp_700nm`
 
     Returns:
-        data (Ndarray): A 2D array of data with headers excluded. Shape (n_samples, n_columns)  
+        data (Ndarray): A 2D array of data with headers excluded. Shape (n_samples, n_columns)
         header (List): Column names or empty strings. Shape (n_columns)
     """
     data_file_name = 'transmission_EO_{:}.csv'.format(filter)
@@ -146,7 +146,7 @@ def load_THORLABS_filter_transmissions(
         ['Wavelength  (nm)', 'Transmission (%)']
 
     Args:
-        filter (str): `DMLP425`, `DMLP550`, `DMLP650`, `FB340-10`, `FBH343-10`, `FBH400-40`, `FBH515-10`, `FBH520-40`, `FBH550-40`, `FEL0400`, `FEL0450`, `FEL0500`, `FEL0550`, `FEL0600`, `FEL0650`, `FEL0700`, `FEL0750`, `FEL0800`, `FEL0850`, `FEL0900`, `FEL0950`, `FEL1000`, `FEL1050`, `FEL1100`, `FEL1150`, `FEL1200`, `FEL1250`, `FEL01300`, `FEL1350`, `FEL1400`, `FEL1450`, `FEL1500`, `FELH1000`, `FELH1050`, `FELH1100`, `FELH1250`, `FELH1500`, `FES0450`, `FES0500`, `FES0550`, `FES0600`, `FES0650`, `FES0700`, `FES0750`, `FES0800`, `FES0850`, `FES0900`, `FES0950`, `FES1000`, `FESH0450`, `FES0500`, `FES0600`, `FES0700`, `FES0750`,  `FGB37`, `FGB39`, `FGS550`, `FGS700`, `FGS900`, `FGUV5`, `FGUV11`, `FL514.5-10`, `FL530-10`, `MF460-60`, `NDUV01B`, `NDUV02B`, `NDUV06B`, `NDUV10B`, `NDUV20B`, `NDUV30B`, `NDUV40B`, `NE01B`, `NE06B`, `NE10B`, `NE20B`, `NE30B`, `NE40B`, `NE50B` or `NE60B` 
+        filter (str): `DMLP425`, `DMLP550`, `DMLP650`, `FB340-10`, `FBH343-10`, `FBH400-40`, `FBH515-10`, `FBH520-40`, `FBH550-40`, `FEL0400`, `FEL0450`, `FEL0500`, `FEL0550`, `FEL0600`, `FEL0650`, `FEL0700`, `FEL0750`, `FEL0800`, `FEL0850`, `FEL0900`, `FEL0950`, `FEL1000`, `FEL1050`, `FEL1100`, `FEL1150`, `FEL1200`, `FEL1250`, `FEL01300`, `FEL1350`, `FEL1400`, `FEL1450`, `FEL1500`, `FELH1000`, `FELH1050`, `FELH1100`, `FELH1250`, `FELH1500`, `FES0450`, `FES0500`, `FES0550`, `FES0600`, `FES0650`, `FES0700`, `FES0750`, `FES0800`, `FES0850`, `FES0900`, `FES0950`, `FES1000`, `FESH0450`, `FES0500`, `FES0600`, `FES0700`, `FES0750`,  `FGB37`, `FGB39`, `FGS550`, `FGS700`, `FGS900`, `FGUV5`, `FGUV11`, `FL514.5-10`, `FL530-10`, `MF460-60`, `NDUV01B`, `NDUV02B`, `NDUV06B`, `NDUV10B`, `NDUV20B`, `NDUV30B`, `NDUV40B`, `NE01B`, `NE06B`, `NE10B`, `NE20B`, `NE30B`, `NE40B`, `NE50B` or `NE60B`
 
     Returns:
         data (Ndarray): A 2D array of data with headers excluded. Shape (n_samples, n_columns)
@@ -183,7 +183,7 @@ def load_EKSMA_OPTICS_mirror_reflections(
         material (str): `Ag`, `Au` or `Al`
 
     Returns:
-        data (Ndarray): A 2D array of data with headers excluded. Shape (n_samples, n_columns) 
+        data (Ndarray): A 2D array of data with headers excluded. Shape (n_samples, n_columns)
         header (List): Column names or empty strings. Shape (n_columns)
 
     """
@@ -201,11 +201,11 @@ def load_EKSMA_OPTICS_mirror_reflections(
 def load_atmospheric_data() -> Tuple[np.ndarray, list]:
     """
     Loads atmospheric data.
-    
+
     Examples:
         >>> from scilightcon.datasets import load_atmospheric_data
         >>> data, header = load_atmospheric_data()
-    
+
     Returns:
         data (Ndarray): A 2D array of data with headers excluded. Shape (n_samples, n_columns)
         header (List): Column names or empty strings. Shape (n_columns)
@@ -225,7 +225,7 @@ def load_atmospheric_data() -> Tuple[np.ndarray, list]:
 def load_materials():
     """
     Loads material database as scilightcon.datasets.materials
-    """    
+    """
     with _open_binary(DATA_MODULE, MATERIALS_PICKLE_FILENAME) as f:
         materials = pickle.load(f)
         return materials

--- a/scilightcon/datasets/_base.py
+++ b/scilightcon/datasets/_base.py
@@ -41,8 +41,8 @@ def load_csv_data(
         target_names (ndarry): A 1D array containing the names of the classifications. For example target_names[0] is the name of the target[0] class. Shape (n_samples,)
 
     """
-    with _get_path(data_module, data_file_name) as csv_file_path:
-        return _read_csv_file(csv_file_path)
+    csv_file_path = _get_path(data_module, data_file_name)
+    return _read_csv_file(csv_file_path)
 
 def _read_csv_file(csv_file_path):
     with open(csv_file_path, 'r') as csv_file:
@@ -93,9 +93,9 @@ def load_zipped_csv_data(data_file_name, *, data_module=DATA_MODULE):
     temp_dir = tempfile.gettempdir()
     temp_path = os.path.join(temp_dir, 'extracted.csv') 
 
-    with _get_path(scilightcon.datasets.DATA_MODULE, data_file_name) as gz_file_path:
-        with gzip.open(gz_file_path, 'r') as file_in:
-             with open(temp_path, 'wb') as file_out:
+    gz_file_path = _get_path(scilightcon.datasets.DATA_MODULE, data_file_name)
+    with gzip.open(gz_file_path, 'r') as file_in:
+            with open(temp_path, 'wb') as file_out:
                 shutil.copyfileobj(file_in, file_out)
     
     return _read_csv_file(temp_path)

--- a/scilightcon/fitting/_detect_peaks.py
+++ b/scilightcon/fitting/_detect_peaks.py
@@ -1,8 +1,8 @@
 from typing import List, Tuple
 import numpy as np
 
-def detect_peaks(x : List[float], y : List[float], method : str, n_max : int, options = {}) -> List[Tuple[int,int]]:
-    """  
+def detect_peaks(x : List[float], y : List[float], method : str, n_max: int=None, options = {}) -> List[Tuple[int,int]]:
+    """
         Peak detection function using different algorithms.
 
         Examples:
@@ -17,19 +17,30 @@ def detect_peaks(x : List[float], y : List[float], method : str, n_max : int, op
             clusters [[22, 25], [12, 15]]
 
         Args:
-            x (float): x axis data  
+            x (float): x axis data
             y (float): y axis data
-            method (str): [`above_average`, `z_score`, `dispersion`]
+            method (str): [`above_average`, `z_score`, `dispersion`, `clusters`]
             n_max (int): Maximum number of peaks
             options (dict): Additional options to pass to the chosen algorithm
 
         Returns:
-            A list of tuples indicating the begining and the end of peaks       
+            A list of tuples indicating the beginning and the end of regions
+            each containing a detected peak.
+
+        Algorithms:
+            - above_average: peaks where signal is above average
+                Options:
+                    - avg (float): custom average value, default: average of all y values
+            - z_score: peaks where signal deviates from average by a given
+                z-score which is a fraction of standard deviation (default: 0.3)
+                Options:
+                    - z_score (float): z-score threshold, default: 0.3
+            - dispersion: TBU
         """
     if method == 'above_average':
-        detected_peaks=_algorithm_ae(x, y)
-    elif method == 'z_score': 
-        detected_peaks=_algorithm_zscore(x, y, z_score = options.get('z_score'))
+        detected_peaks=_algorithm_ae(x, y, avg=options.get('avg'))
+    elif method == 'z_score':
+        detected_peaks=_algorithm_zscore(x, y, z_score=options.get('z_score'))
     elif method == 'dispersion':
         detected_peaks=_algorithm_dispersion(x, y)
     else:
@@ -37,17 +48,17 @@ def detect_peaks(x : List[float], y : List[float], method : str, n_max : int, op
 
     return _analyze_clusters(y, detected_peaks, n_max)
 
-def _algorithm_ae(x,y):
-    avg = np.average(y)
+def _algorithm_ae(x, y, avg=None):
+    avg = avg or np.average(y)
     return np.array([1.0 if item > avg else 0.0 for item in y])
 
-def _algorithm_zscore(x,y, z_score = None):
+def _algorithm_zscore(x,y, z_score=None):
     z_score = z_score or 0.3
     avg = np.average(y)
     std = np.std(y)
     return np.array([1.0 if np.abs(item - avg) > std * z_score else 0.0 for item in y])
 
-def _algorithm_dispersion(x, y):    
+def _algorithm_dispersion(x, y):
     lag = 100
     if lag > len(x):
         lag = int(len(x)/2)
@@ -70,16 +81,46 @@ def _algorithm_dispersion(x, y):
             y_processed = np.append(y_processed, [y_val])
     return np.roll(y_peak, i_start)
 
-def _analyze_clusters(y, y_peak, n_max):
+def _analyze_clusters(y, y_peak, n_max=None):
+    """Determine peak regions by analyzing clusters of detected peak points.
+
+    Peak regions are defined as contiguous sequences of points where peaks
+    are detected in y_peak. Each region is represented by a [from, to] index
+    tuple.
+
+    If `n_max` is specified and the number of detected peaks is larger than
+    n_max, only n_max largest peaks are returned.
+
+        Args:
+            y (float arr): noisy data with peaks
+            y_peak (float arr): binary mask where peaks are detected
+            n_max (int): maximum number of peaks to return or None to return all
+
+        Returns:
+            A list of [from, to] index tuples where a peak is found in y, up to
+            n_max peaks.
+    """
     clusters = []
+
+    # Find peak regions in y_peak mask
     for i in np.arange(len(y)-1):
+        # If a mask starts with a high value, or there's a transition from low
+        # to high, start a new cluster
         if (y_peak[i]==1.0 and i==0) or (y_peak[i]==0.0 and y_peak[i+1]!=0.0):
             clusters = clusters + [[i,0]]
+
+        # If a mask ends with a high value, or there's a transition from high
+        # to low, end the current cluster
         if (y_peak[i]==1.0 and i==(len(y)-2)) or (y_peak[i]!=0.0 and y_peak[i+1]==0.0):
             clusters[-1][1] = i
+
+    # Sort clusters by by peak height
     n_clusters = len(clusters)
     cluster_avgs = [np.abs(np.sum(y[(span[0]):(span[1])])) for span in clusters]
     cluster_max_args = np.argsort(cluster_avgs)[::-1]
 
-    clusters = [clusters[cluster_max_args[i]] for i in np.arange(np.min([n_max, n_clusters]))]
+    if n_max:
+        # Return only the n_max largest clusters
+        clusters = [clusters[cluster_max_args[i]] for i in np.arange(np.min([n_max, n_clusters]))]
+
     return clusters

--- a/tests/test_loggs_reader.py
+++ b/tests/test_loggs_reader.py
@@ -5,13 +5,12 @@ from  zipfile import  ZipFile
 from scilightcon.datasets._logs_reader import LogsReader
 from scilightcon.utils._fixes import _get_path
 import tempfile
-import os 
+import os
 
 temp_dir = tempfile.mkdtemp()
-
-with _get_path(scilightcon.datasets.DATA_MODULE, 'logsreader_test.zip') as zip_file_path:
-    with ZipFile(zip_file_path, 'r') as zip_ref:
-        zip_ref.extractall(temp_dir)
+zip_file_path = _get_path(scilightcon.datasets.DATA_MODULE, 'logsreader_test.zip')
+with ZipFile(zip_file_path, 'r') as zip_ref:
+    zip_ref.extractall(temp_dir)
 
 filepath = os.path.join(temp_dir, 'logsreader_test')
 reader = LogsReader(filepath)
@@ -44,5 +43,5 @@ def test_get_data():
     # 2 - raises ValueError when measurable not found
     with pytest.raises(ValueError):
         reader.get_data(logger_name= "Device 1", measurable = "idk", from_date = from_date, to_date = to_date)
-    
+
 

--- a/tests/test_utils_load_s2s_data.py
+++ b/tests/test_utils_load_s2s_data.py
@@ -4,8 +4,7 @@ from scilightcon.utils._fixes import _get_path
 from importlib import resources
 
 def test_utils_load_s2s_data():
-
-    with _get_path(scilightcon.datasets.DATA_MODULE, 'Shot-to-shot_LAB4 PHAROS_25.0kHz_1030nm_InGaAs_20210917_1337.s2s') as filepath:
-        s2s_data = load_s2s_data(filepath)
+    file_path = _get_path(scilightcon.datasets.DATA_MODULE, 'Shot-to-shot_LAB4 PHAROS_25.0kHz_1030nm_InGaAs_20210917_1337.s2s')
+    s2s_data = load_s2s_data(file_path)
 
     assert(len(s2s_data.outliers) == 5)


### PR DESCRIPTION
- `n_max` in `detect_peaks()` is now optional. Passing None returns all detected peaks and keeps them sorted along the time/index axis.
- The 'above_average' algorithm now takes an explicit `avg` option, specifying it skips internal average calculation.
- Expanded docstring and added comments for clarity

Fixed related to the main branch not getting built in a while:
- Removed with Path as var paradigm as Path object use as context managers has been deprecated in Python v3.9 and removed  v3.13, see [CPython discussion](https://github.com/python/cpython/pull/104807)
- Updated azure pipelines from lkdev as the master branch seems to not have been updated previously